### PR TITLE
Change mobile layout so everything is bigger and responsive

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,56 +3,81 @@
 <head>
 	<link href="https://fonts.googleapis.com/css?family=Oswald" rel="stylesheet">
 	<title>The Left Bit</title>
+	<meta name="viewport" content="initial-scale=1, maximum-scale=1">
 	<style>
+	html {
+		font-size: 62.5%;
+	}
 	body {
 		font-family: 'Oswald', sans-serif;
 		background: black;
-		color: white;
 		font-weight: bold;
+		color: white;
+		margin: 0;
 	}
-	#logo path {
+	svg path {
 		fill: white;
 	}
-	#logo {
-		width: 200px;
-		margin-top: 30px;
+	svg {
 		margin-left: 30px;
+		margin-top: 30px;
+		width: 200px;
 	}
 	a {
 		text-decoration: underline;
 		color: inherit;
 	}
-	#working {
-		font-weight: 500;
-		font-size: 50px;
+	p {
 		position: absolute;
-		bottom: 0;
-		line-height: 1.2;
 		margin-left: 30px;
+		font-weight: 500;
+		line-height: 1.2;
+		font-size: 5rem;
+		bottom: 0;
 	}
-	@media (max-width: 770px) {
-		#working {
-			font-size: 40px;
+	@media screen and (max-width: 770px) {
+		body {
+			height: calc(100vh - 60px);
+			position: relative;
+			margin: 30px;
 		}
-	@media (max-width: 620px) {
-		#working {
-			font-size: 26px;
+		html {
+			font-size: 50%;
 		}
-	@media (max-width: 420px) {
-		#logo {
+	}
+	@media screen and (max-width: 620px) {
+		html {
+			font-size: 40%;
+		}
+	}
+	@media screen and (max-width: 420px) {
+		svg {
+			position: absolute;
 			margin-left: 0;
 			margin-top: 0;
-			width: 100%;
+			height: 35vh;
+			width: auto;
+			left: 0;
+			top: 0;
 		}
-		#working {
-			margin-left: 0;
-			font-size: 20px;
+		p {
+			position: absolute;
+			bottom: 0;
+			margin: 0;
+			left: 0;
+		}
+		br:first-child {
+			display: none;
+		}
+		a {
+			margin-top: 30px;
+			display: block;
 		}
 	}
 		</style>
 	</head>
 	<body>
-		<svg id="logo" version="1.2" baseProfile="tiny" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+		<svg version="1.2" baseProfile="tiny" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
 		x="0px" y="0px" viewBox="170 55 500 490" xml:space="preserve">
 		<path d="M223.2,466.4c-1-0.3-1.7-1.2-1.7-2.2v0v0c0-1.1,0.7-2,1.7-2.2c4.3-1.2,15.3-5.3,17.4-18.2c2.6-16.1-0.5-44.1-8.2-50.1
 		c-7.2-5.6-13.3-5.6-15.1-5.6h-17.4c-6.9,0-12.5,5.6-12.5,12.5v63.7v58.7c0,9.7,7.8,17.5,17.5,17.5h12.5c1.9,0,7.9,0,15.1-5.6
@@ -75,6 +100,6 @@
 		<path d="M282.8,405.4v-17.5h-7.4h-20.1h-7.4v17.5h4.6c1.6,0,2.8,1.3,2.8,2.8V520c0,1.6-1.3,2.8-2.8,2.8h-4.6v17.5h7.4h20.1h7.4
 		v-17.5h-4.6c-1.6,0-2.8-1.3-2.8-2.8V408.2c0-1.6,1.3-2.8,2.8-2.8H282.8z"/>
 	</svg>
-	<p id="working">Mobile App Developers clearly working</br>on making this web better.</br><a href="mailto:hola@theleftbit.com">hola@theleftbit.com</a></p>
+	<p>Mobile App Developers clearly working</br>on making this web better.</br><a href="mailto:hola@theleftbit.com">hola@theleftbit.com</a></p>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -100,6 +100,6 @@
 		<path d="M282.8,405.4v-17.5h-7.4h-20.1h-7.4v17.5h4.6c1.6,0,2.8,1.3,2.8,2.8V520c0,1.6-1.3,2.8-2.8,2.8h-4.6v17.5h7.4h20.1h7.4
 		v-17.5h-4.6c-1.6,0-2.8-1.3-2.8-2.8V408.2c0-1.6,1.3-2.8,2.8-2.8H282.8z"/>
 	</svg>
-	<p>Mobile App Developers clearly working</br>on making this web better.</br><a href="mailto:hola@theleftbit.com">hola@theleftbit.com</a></p>
+	<p>Mobile App Developers clearly working </br>on making this web better.</br><a href="mailto:hola@theleftbit.com">hola@theleftbit.com</a></p>
 </body>
 </html>


### PR DESCRIPTION
This PR changes the layout a little bit so it's responsive on mobile and it takes more screen, maintaining the left alignment, which @ignasi already told me is a brand feature :laughing: 

The height of the logo in mobile is set to `35vh`, which means it will take 35% of the **view height**, whatever it is.

The font sizes are fully responsive using the % & rem method.

Here you have screens of the result in different phones: iPhone 5SE, iPhone X, Galaxy S5, Pixel 2 XL.

![_home_jeff_workspace_theleftbit github io_index html iphone 5_se](https://user-images.githubusercontent.com/3155133/36421692-da8683dc-1639-11e8-88e1-6445053873b2.png)
![_home_jeff_workspace_theleftbit github io_index html iphone x](https://user-images.githubusercontent.com/3155133/36421693-daa7b1ba-1639-11e8-939d-e6cdfd46fd5d.png)
![_home_jeff_workspace_theleftbit github io_index html galaxy s5](https://user-images.githubusercontent.com/3155133/36421694-dac8268e-1639-11e8-9fd5-237490759711.png)
![_home_jeff_workspace_theleftbit github io_index html pixel 2 xl](https://user-images.githubusercontent.com/3155133/36421695-daeac054-1639-11e8-89c7-9db6b20bb2e4.png)



